### PR TITLE
Cleanup VPN MCP server skeleton

### DIFF
--- a/server/mcp_server_vpn/README.md
+++ b/server/mcp_server_vpn/README.md
@@ -1,0 +1,20 @@
+
+# VPN MCP Server
+
+Skeleton MCP server for VPN related tools. Functionality will be added in future versions.
+
+## Usage
+Install the dependencies with `uv` and run the server:
+
+```bash
+uv run mcp-server-vpn
+```
+
+To use SSE transport:
+```bash
+uv run mcp-server-vpn -t sse
+```
+
+## License
+
+volcengine/mcp-server is licensed under the MIT License.

--- a/server/mcp_server_vpn/pyproject.toml
+++ b/server/mcp_server_vpn/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "mcp-server-vpn"
+version = "1.0.0"
+description = "VPN MCP Server"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "mcp>=1.9.0"
+]
+
+[project.scripts]
+mcp-server-vpn = "mcp_server_vpn.main:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/server/mcp_server_vpn/src/mcp_server_vpn/main.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/main.py
@@ -1,0 +1,29 @@
+import argparse
+import logging
+
+from mcp_server_vpn.server import mcp
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the VPN MCP Server")
+    parser.add_argument(
+        "--transport",
+        "-t",
+        choices=["stdio", "sse"],
+        default="stdio",
+        help="Transport protocol to use",
+    )
+    args = parser.parse_args()
+
+    logger.info("Starting VPN MCP Server with %s transport", args.transport)
+    mcp.run(transport=args.transport)
+
+
+if __name__ == "__main__":
+    main()

--- a/server/mcp_server_vpn/src/mcp_server_vpn/server.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/server.py
@@ -1,0 +1,14 @@
+import logging
+import os
+
+from mcp.server.fastmcp import FastMCP
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+mcp = FastMCP("VPN MCP Server", port=int(os.getenv("PORT", "8000")))
+
+# TODO: Add VPN related tools here


### PR DESCRIPTION
## Summary
- simplify VPN README to describe a basic skeleton
- remove demo tools from VPN server implementation

## Testing
- `python -m py_compile server/mcp_server_vpn/src/mcp_server_vpn/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6864e150f8348333be99b89c8fbb159c