### PR TITLE
Add uv install guide for VPN server

### DIFF
--- a/server/mcp_server_vpn/README.md
+++ b/server/mcp_server_vpn/README.md
@@ -3,6 +3,23 @@
 
 Skeleton MCP server for VPN related tools. Functionality will be added in future versions.
 
+## Installation
+
+### System requirements
+- Python 3.11 or higher
+- [uv](https://github.com/astral-sh/uv) package manager
+
+### Install uv
+**Linux/macOS:**
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+**Windows:**
+```bash
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
 ## Usage
 Install the dependencies with `uv` and run the server:
 


### PR DESCRIPTION
## Summary
- update VPN MCP Server README with uv installation instructions

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'build')*

------
https://chatgpt.com/codex/tasks/task_e_6864ecea09c083339847ad57a2069267