### PR TITLE
Rename VPN wrapper class

### DIFF
--- a/server/mcp_server_vpn/src/mcp_server_vpn/clients/__init__.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/clients/__init__.py
@@ -1,0 +1,3 @@
+from .vpn import VPNClient
+
+__all__ = ["VPNClient"]

--- a/server/mcp_server_vpn/src/mcp_server_vpn/clients/vpn.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/clients/vpn.py
@@ -6,7 +6,7 @@ from volcenginesdkvpn.models import (
 )
 
 
-class VPNSDK:
+class VPNClient:
     """Simple wrapper around the volcenginesdk VPN client."""
 
     def __init__(

--- a/server/mcp_server_vpn/src/mcp_server_vpn/resource/__init__.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/resource/__init__.py
@@ -1,1 +1,0 @@
-from .vpn_resource import VPNSDK

--- a/server/mcp_server_vpn/src/mcp_server_vpn/server.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/server.py
@@ -8,7 +8,7 @@ from mcp.server.fastmcp import FastMCP, Context
 from mcp.server.session import ServerSession
 from starlette.requests import Request
 
-from .resource.vpn_resource import VPNSDK
+from .clients import VPNClient
 
 logging.basicConfig(
     level=logging.INFO,
@@ -33,10 +33,10 @@ def _read_sts() -> dict:
     return json.loads(decoded)
 
 
-def _get_vpn_resource() -> VPNSDK:
-    """Create a VPNSDK instance using STS credentials."""
+def _get_vpn_client() -> VPNClient:
+    """Create a VPN client instance using STS credentials."""
     creds = _read_sts()
-    return VPNSDK(
+    return VPNClient(
         region=os.getenv("VOLCENGINE_REGION"),
         ak=creds.get("AccessKeyId"),
         sk=creds.get("SecretAccessKey"),
@@ -51,7 +51,7 @@ def describe_vpn_connection(vpn_connection_id: str) -> dict[str, Any]:
     Args:
         vpn_connection_id: IPsec 连接的ID。
     """
-    vpn_resource = _get_vpn_resource()
+    vpn_client = _get_vpn_client()
     req = {"VpnConnectionId": vpn_connection_id}
-    resp = vpn_resource.describe_vpn_connection_attributes(req)
+    resp = vpn_client.describe_vpn_connection_attributes(req)
     return resp.to_dict()


### PR DESCRIPTION
## Summary
- change wrapper class to `VPNClient`
- re-export `VPNClient` from the clients package
- update server to construct and use `VPNClient`
- rename helper to `_get_vpn_client`

## Testing
- `python -m compileall -q server/mcp_server_vpn/src/mcp_server_vpn`


------
https://chatgpt.com/codex/tasks/task_e_6865249d4c808333be46c2bcc703a7fd