### PR TITLE
Implement signal-based shutdown for VPN server

### DIFF
--- a/server/mcp_server_vpn/src/mcp_server_vpn/main.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/main.py
@@ -1,5 +1,8 @@
 import argparse
 import logging
+import signal
+import sys
+import threading
 
 from mcp_server_vpn.server import mcp
 
@@ -22,7 +25,35 @@ def main() -> None:
     args = parser.parse_args()
 
     logger.info("Starting VPN MCP Server with %s transport", args.transport)
-    mcp.run(transport=args.transport)
+
+    stop_event = threading.Event()
+
+    def run_server() -> None:
+        try:
+            mcp.run(transport=args.transport)
+        finally:
+            stop_event.set()
+
+    def handle_signal(signum, frame) -> None:  # noqa: D401
+        """Handle termination signals and shut down the server."""
+        logger.info("Received signal %s, shutting down gracefully", signum)
+        shutdown = getattr(mcp, "shutdown", None)
+        if callable(shutdown):
+            try:
+                shutdown()
+            except Exception as exc:  # pragma: no cover - best effort
+                logger.error("Error during shutdown: %s", exc)
+        stop_event.set()
+
+    signal.signal(signal.SIGINT, handle_signal)
+    signal.signal(signal.SIGTERM, handle_signal)
+
+    thread = threading.Thread(target=run_server, name="mcp-server")
+    thread.start()
+
+    stop_event.wait()
+    logger.info("Server shutdown complete")
+    sys.exit(0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add signal handling to VPN MCP server to allow graceful shutdown

## Testing
- `python -m py_compile server/mcp_server_vpn/src/mcp_server_vpn/main.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'build')*

------
https://chatgpt.com/codex/tasks/task_e_68663282678883339a816b8a30dea491