### PR TITLE
Add VPN connections listing tool

### DIFF
--- a/server/mcp_server_vpn/README.md
+++ b/server/mcp_server_vpn/README.md
@@ -15,6 +15,11 @@ Skeleton MCP server for VPN related tools. Functionality will be added in future
 - **详细描述**：查询指定的 VPN 网关详情。
 - **触发示例**：`"查看 VPN 网关 vgw-123 的状态"`
 
+### `describe_vpn_connections`
+
+- **详细描述**：查询满足条件的 IPsec 连接列表。
+- **触发示例**：`"列出所有 IPsec 连接"`
+
 ## Installation
 
 ### System requirements

--- a/server/mcp_server_vpn/src/mcp_server_vpn/clients/vpn.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/clients/vpn.py
@@ -3,6 +3,8 @@ from volcenginesdkvpn.api.vpn_api import VPNApi
 from volcenginesdkvpn.models import (
     DescribeVpnConnectionAttributesRequest,
     DescribeVpnConnectionAttributesResponse,
+    DescribeVpnConnectionsRequest,
+    DescribeVpnConnectionsResponse,
     DescribeVpnGatewayAttributesRequest,
     DescribeVpnGatewayAttributesResponse,
 )
@@ -37,3 +39,9 @@ class VPNClient:
     ) -> DescribeVpnGatewayAttributesResponse:
         """Query details of a specific VPN gateway."""
         return self.client.describe_vpn_gateway_attributes(request)
+
+    def describe_vpn_connections(
+        self, request: DescribeVpnConnectionsRequest
+    ) -> DescribeVpnConnectionsResponse:
+        """Query a list of VPN connections."""
+        return self.client.describe_vpn_connections(request)

--- a/server/mcp_server_vpn/src/mcp_server_vpn/server.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/server.py
@@ -3,16 +3,17 @@ import json
 import logging
 import os
 
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.session import ServerSession
+from starlette.requests import Request
 from volcenginesdkvpn.models import (
     DescribeVpnConnectionAttributesRequest,
     DescribeVpnConnectionAttributesResponse,
+    DescribeVpnConnectionsRequest,
+    DescribeVpnConnectionsResponse,
     DescribeVpnGatewayAttributesRequest,
     DescribeVpnGatewayAttributesResponse,
 )
-
-from mcp.server.fastmcp import FastMCP, Context
-from mcp.server.session import ServerSession
-from starlette.requests import Request
 
 from .clients import VPNClient
 
@@ -82,4 +83,29 @@ def describe_vpn_gateway(
         return resp
     except Exception:
         logger.exception("Error calling describe_vpn_gateway")
+        raise
+
+
+@mcp.tool(name="describe_vpn_connections", description="查询满足条件的IPsec连接")
+def describe_vpn_connections(
+    page_number: int | None = None,
+    page_size: int | None = None,
+    vpn_gateway_id: str | None = None,
+    vpn_connection_name: str | None = None,
+    status: str | None = None,
+) -> DescribeVpnConnectionsResponse:
+    """查询IPsec连接列表。"""
+    vpn_client = _get_vpn_client()
+    req = DescribeVpnConnectionsRequest(
+        page_number=page_number,
+        page_size=page_size,
+        vpn_gateway_id=vpn_gateway_id,
+        vpn_connection_name=vpn_connection_name,
+        status=status,
+    )
+    try:
+        resp = vpn_client.describe_vpn_connections(req)
+        return resp
+    except Exception:
+        logger.exception("Error calling describe_vpn_connections")
         raise


### PR DESCRIPTION
## Summary
- add a new tool `describe_vpn_connections`
- wrap `DescribeVpnConnections` API in VPN client
- document the new tool in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'build')*

------
https://chatgpt.com/codex/tasks/task_e_68667f87670c8333bb8c591f4e7ab328