### PR TITLE
Implement Pydantic wrappers for VPN responses

### DIFF
--- a/server/mcp_server_vpn/src/mcp_server_vpn/clients/__init__.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/clients/__init__.py
@@ -1,3 +1,13 @@
 from .vpn import VPNClient
+from .models import (
+    DescribeVpnConnectionAttributesResponse,
+    DescribeVpnGatewayAttributesResponse,
+    DescribeVpnConnectionsResponse,
+)
 
-__all__ = ["VPNClient"]
+__all__ = [
+    "VPNClient",
+    "DescribeVpnConnectionAttributesResponse",
+    "DescribeVpnGatewayAttributesResponse",
+    "DescribeVpnConnectionsResponse",
+]

--- a/server/mcp_server_vpn/src/mcp_server_vpn/clients/models.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/clients/models.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel
+
+class BaseResponseModel(BaseModel):
+    """Generic response model allowing extra fields."""
+
+    class Config:
+        extra = "allow"
+        arbitrary_types_allowed = True
+
+
+class DescribeVpnConnectionAttributesResponse(BaseResponseModel):
+    pass
+
+
+class DescribeVpnGatewayAttributesResponse(BaseResponseModel):
+    pass
+
+
+class DescribeVpnConnectionsResponse(BaseResponseModel):
+    pass

--- a/server/mcp_server_vpn/src/mcp_server_vpn/clients/vpn.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/clients/vpn.py
@@ -6,11 +6,14 @@ from volcenginesdkcore.rest import ApiException
 from volcenginesdkvpn.api.vpn_api import VPNApi
 from volcenginesdkvpn.models import (
     DescribeVpnConnectionAttributesRequest,
-    DescribeVpnConnectionAttributesResponse,
     DescribeVpnConnectionsRequest,
-    DescribeVpnConnectionsResponse,
     DescribeVpnGatewayAttributesRequest,
+)
+
+from .models import (
+    DescribeVpnConnectionAttributesResponse,
     DescribeVpnGatewayAttributesResponse,
+    DescribeVpnConnectionsResponse,
 )
 
 
@@ -54,17 +57,32 @@ class VPNClient:
                     raise
                 time.sleep(self._backoff * 2 ** (i - 1))
 
+    @staticmethod
+    def _wrap(resp, model_cls):
+        if hasattr(resp, "to_dict"):
+            data = resp.to_dict()
+        elif hasattr(resp, "model_dump"):
+            data = resp.model_dump()
+        elif isinstance(resp, dict):
+            data = resp
+        else:
+            data = getattr(resp, "__dict__", {})
+        return model_cls(**data)
+
     def describe_vpn_connection_attributes(
         self, request: DescribeVpnConnectionAttributesRequest
     ) -> DescribeVpnConnectionAttributesResponse:
-        return self._call(self.client.describe_vpn_connection_attributes, request)
+        resp = self._call(self.client.describe_vpn_connection_attributes, request)
+        return self._wrap(resp, DescribeVpnConnectionAttributesResponse)
 
     def describe_vpn_gateway_attributes(
         self, request: DescribeVpnGatewayAttributesRequest
     ) -> DescribeVpnGatewayAttributesResponse:
-        return self._call(self.client.describe_vpn_gateway_attributes, request)
+        resp = self._call(self.client.describe_vpn_gateway_attributes, request)
+        return self._wrap(resp, DescribeVpnGatewayAttributesResponse)
 
     def describe_vpn_connections(
         self, request: DescribeVpnConnectionsRequest
     ) -> DescribeVpnConnectionsResponse:
-        return self._call(self.client.describe_vpn_connections, request)
+        resp = self._call(self.client.describe_vpn_connections, request)
+        return self._wrap(resp, DescribeVpnConnectionsResponse)


### PR DESCRIPTION
## Summary
- create pydantic response models for the VPN client
- wrap SDK responses in these models
- export response classes from the clients package
- adjust unit tests to use the new models
- revert unrelated test modifications

## Testing
- `pytest server/mcp_server_vpn/tests/test_server.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686bb55469fc8333bad6c1b710e9198a