### PR TITLE
Add DescribeVpnGateways tool

### DIFF
--- a/server/mcp_server_vpn/README.md
+++ b/server/mcp_server_vpn/README.md
@@ -20,6 +20,11 @@ Skeleton MCP server for VPN related tools. Functionality will be added in future
 - **详细描述**：查询满足条件的 IPsec 连接列表。
 - **触发示例**：`"列出所有 IPsec 连接"`
 
+### `describe_vpn_gateways`
+
+- **详细描述**：查询满足条件的 VPN 网关列表。
+- **触发示例**：`"列出所有 VPN 网关"`
+
 ## Installation
 
 ### System requirements

--- a/server/mcp_server_vpn/src/mcp_server_vpn/clients/__init__.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/clients/__init__.py
@@ -3,6 +3,7 @@ from .models import (
     DescribeVpnConnectionAttributesResponse,
     DescribeVpnGatewayAttributesResponse,
     DescribeVpnConnectionsResponse,
+    DescribeVpnGatewaysResponse,
 )
 
 __all__ = [
@@ -10,4 +11,5 @@ __all__ = [
     "DescribeVpnConnectionAttributesResponse",
     "DescribeVpnGatewayAttributesResponse",
     "DescribeVpnConnectionsResponse",
+    "DescribeVpnGatewaysResponse",
 ]

--- a/server/mcp_server_vpn/src/mcp_server_vpn/clients/models.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/clients/models.py
@@ -19,3 +19,7 @@ class DescribeVpnGatewayAttributesResponse(BaseResponseModel):
 
 class DescribeVpnConnectionsResponse(BaseResponseModel):
     pass
+
+
+class DescribeVpnGatewaysResponse(BaseResponseModel):
+    pass

--- a/server/mcp_server_vpn/src/mcp_server_vpn/clients/vpn.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/clients/vpn.py
@@ -8,12 +8,14 @@ from volcenginesdkvpn.models import (
     DescribeVpnConnectionAttributesRequest,
     DescribeVpnConnectionsRequest,
     DescribeVpnGatewayAttributesRequest,
+    DescribeVpnGatewaysRequest,
 )
 
 from .models import (
     DescribeVpnConnectionAttributesResponse,
     DescribeVpnGatewayAttributesResponse,
     DescribeVpnConnectionsResponse,
+    DescribeVpnGatewaysResponse,
 )
 
 
@@ -86,3 +88,9 @@ class VPNClient:
     ) -> DescribeVpnConnectionsResponse:
         resp = self._call(self.client.describe_vpn_connections, request)
         return self._wrap(resp, DescribeVpnConnectionsResponse)
+
+    def describe_vpn_gateways(
+        self, request: DescribeVpnGatewaysRequest
+    ) -> DescribeVpnGatewaysResponse:
+        resp = self._call(self.client.describe_vpn_gateways, request)
+        return self._wrap(resp, DescribeVpnGatewaysResponse)

--- a/server/mcp_server_vpn/tests/test_server.py
+++ b/server/mcp_server_vpn/tests/test_server.py
@@ -49,6 +49,8 @@ models_mod.DescribeVpnConnectionsRequest = BaseReq
 models_mod.DescribeVpnConnectionsResponse = Resp
 models_mod.DescribeVpnGatewayAttributesRequest = BaseReq
 models_mod.DescribeVpnGatewayAttributesResponse = Resp
+models_mod.DescribeVpnGatewaysRequest = BaseReq
+models_mod.DescribeVpnGatewaysResponse = Resp
 sys.modules['volcenginesdkcore'] = core
 sys.modules['volcenginesdkcore.rest'] = core.rest
 sys.modules['volcenginesdkvpn'] = vpn_mod
@@ -132,6 +134,12 @@ class StubClient:
         from mcp_server_vpn.clients.models import DescribeVpnConnectionAttributesResponse
         return DescribeVpnConnectionAttributesResponse(Message="ok")
 
+    def describe_vpn_gateways(self, req):
+        if self.exc:
+            raise self.exc
+        from mcp_server_vpn.clients.models import DescribeVpnGatewaysResponse
+        return DescribeVpnGatewaysResponse(Message="ok")
+
 
 def test_describe_vpn_connection_success(monkeypatch):
     monkeypatch.setattr(server, '_get_vpn_client', lambda region=None: StubClient())
@@ -164,4 +172,16 @@ def test_get_vpn_client_missing_vars(monkeypatch):
 def test_describe_vpn_connection_missing_creds(monkeypatch):
     monkeypatch.setattr(server, '_get_vpn_client', lambda region=None: (_ for _ in ()).throw(ValueError('Missing required credentials')))
     result = asyncio.run(server.describe_vpn_connection('id'))
+    assert isinstance(result, CallToolResult) and result.isError
+
+
+def test_describe_vpn_gateways_success(monkeypatch):
+    monkeypatch.setattr(server, '_get_vpn_client', lambda region=None: StubClient())
+    result = asyncio.run(server.describe_vpn_gateways())
+    assert result.Message == 'ok'
+
+
+def test_describe_vpn_gateways_error(monkeypatch):
+    monkeypatch.setattr(server, '_get_vpn_client', lambda region=None: StubClient(Exception('boom')))
+    result = asyncio.run(server.describe_vpn_gateways())
     assert isinstance(result, CallToolResult) and result.isError


### PR DESCRIPTION
## Summary
- support listing VPN gateways via new client method
- expose DescribeVpnGateways in client API
- implement `describe_vpn_gateways` MCP tool
- document the new tool
- test success and error paths for the new tool

## Testing
- `pytest server/mcp_server_vpn/tests/test_server.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686cd8ea846c8333af723741a3783860