### PR TITLE
Add VPN gateway route tool

### DIFF
--- a/server/mcp_server_vpn/README.md
+++ b/server/mcp_server_vpn/README.md
@@ -25,6 +25,11 @@ Skeleton MCP server for VPN related tools. Functionality will be added in future
 - **详细描述**：查询满足条件的 VPN 网关列表。
 - **触发示例**：`"列出所有 VPN 网关"`
 
+### `describe_vpn_gateway_route`
+
+- **详细描述**：查询指定的 VPN 网关路由条目详情。
+- **触发示例**：`"查看 VPN 网关路由 vgr-123 的配置"`
+
 ## Installation
 
 ### System requirements

--- a/server/mcp_server_vpn/src/mcp_server_vpn/clients/models.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/clients/models.py
@@ -23,3 +23,7 @@ class DescribeVpnConnectionsResponse(BaseResponseModel):
 
 class DescribeVpnGatewaysResponse(BaseResponseModel):
     pass
+
+
+class DescribeVpnGatewayRouteAttributesResponse(BaseResponseModel):
+    pass

--- a/server/mcp_server_vpn/src/mcp_server_vpn/clients/vpn.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/clients/vpn.py
@@ -9,6 +9,7 @@ from volcenginesdkvpn.models import (
     DescribeVpnConnectionsRequest,
     DescribeVpnGatewayAttributesRequest,
     DescribeVpnGatewaysRequest,
+    DescribeVpnGatewayRouteAttributesRequest,
 )
 
 from .models import (
@@ -16,6 +17,7 @@ from .models import (
     DescribeVpnGatewayAttributesResponse,
     DescribeVpnConnectionsResponse,
     DescribeVpnGatewaysResponse,
+    DescribeVpnGatewayRouteAttributesResponse,
 )
 
 
@@ -94,3 +96,11 @@ class VPNClient:
     ) -> DescribeVpnGatewaysResponse:
         resp = self._call(self.client.describe_vpn_gateways, request)
         return self._wrap(resp, DescribeVpnGatewaysResponse)
+
+    def describe_vpn_gateway_route_attributes(
+        self, request: DescribeVpnGatewayRouteAttributesRequest
+    ) -> DescribeVpnGatewayRouteAttributesResponse:
+        resp = self._call(
+            self.client.describe_vpn_gateway_route_attributes, request
+        )
+        return self._wrap(resp, DescribeVpnGatewayRouteAttributesResponse)

--- a/server/mcp_server_vpn/src/mcp_server_vpn/server.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/server.py
@@ -12,6 +12,7 @@ from volcenginesdkvpn.models import (
     DescribeVpnConnectionsRequest,
     DescribeVpnGatewayAttributesRequest,
     DescribeVpnGatewaysRequest,
+    DescribeVpnGatewayRouteAttributesRequest,
 )
 
 from mcp.types import CallToolResult, TextContent, ToolAnnotations
@@ -22,6 +23,7 @@ from .clients.models import (
     DescribeVpnConnectionsResponse,
     DescribeVpnConnectionAttributesResponse,
     DescribeVpnGatewaysResponse,
+    DescribeVpnGatewayRouteAttributesResponse,
 )
 
 logging.basicConfig(
@@ -152,6 +154,40 @@ async def describe_vpn_gateway(
         )
     except Exception as exc:
         logger.exception("Error calling describe_vpn_gateway")
+        return CallToolResult(
+            isError=True,
+            content=[TextContent(type="text", text=f"查询失败：{exc}")],
+        )
+
+
+@mcp.tool(
+    name="describe_vpn_gateway_route",
+    description=(
+        '查询指定的VPN网关路由条目详情。\n\n示例：{"vpn_gateway_route_id":"vgr-xxx","region":"cn-beijing"}'
+    ),
+    annotations=ToolAnnotations(
+        title="Query VPN Gateway Route / 查询 VPN 网关路由详情",
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=True,
+    ),
+)
+async def describe_vpn_gateway_route(
+    vpn_gateway_route_id: str,
+    region: str | None = None,
+) -> DescribeVpnGatewayRouteAttributesResponse | CallToolResult:
+    req = DescribeVpnGatewayRouteAttributesRequest(vpn_gateway_route_id=vpn_gateway_route_id)
+    try:
+        vpn_client = _get_vpn_client(region=region)
+        resp = vpn_client.describe_vpn_gateway_route_attributes(req)
+        return resp
+    except ValueError as exc:
+        return CallToolResult(
+            isError=True,
+            content=[TextContent(type="text", text=f"凭证缺失：{exc}")],
+        )
+    except Exception as exc:
+        logger.exception("Error calling describe_vpn_gateway_route")
         return CallToolResult(
             isError=True,
             content=[TextContent(type="text", text=f"查询失败：{exc}")],

--- a/server/mcp_server_vpn/tests/test_server.py
+++ b/server/mcp_server_vpn/tests/test_server.py
@@ -51,6 +51,8 @@ models_mod.DescribeVpnGatewayAttributesRequest = BaseReq
 models_mod.DescribeVpnGatewayAttributesResponse = Resp
 models_mod.DescribeVpnGatewaysRequest = BaseReq
 models_mod.DescribeVpnGatewaysResponse = Resp
+models_mod.DescribeVpnGatewayRouteAttributesRequest = BaseReq
+models_mod.DescribeVpnGatewayRouteAttributesResponse = Resp
 sys.modules['volcenginesdkcore'] = core
 sys.modules['volcenginesdkcore.rest'] = core.rest
 sys.modules['volcenginesdkvpn'] = vpn_mod
@@ -140,6 +142,14 @@ class StubClient:
         from mcp_server_vpn.clients.models import DescribeVpnGatewaysResponse
         return DescribeVpnGatewaysResponse(Message="ok")
 
+    def describe_vpn_gateway_route_attributes(self, req):
+        if self.exc:
+            raise self.exc
+        from mcp_server_vpn.clients.models import (
+            DescribeVpnGatewayRouteAttributesResponse,
+        )
+        return DescribeVpnGatewayRouteAttributesResponse(Message="ok")
+
 
 def test_describe_vpn_connection_success(monkeypatch):
     monkeypatch.setattr(server, '_get_vpn_client', lambda region=None: StubClient())
@@ -184,4 +194,16 @@ def test_describe_vpn_gateways_success(monkeypatch):
 def test_describe_vpn_gateways_error(monkeypatch):
     monkeypatch.setattr(server, '_get_vpn_client', lambda region=None: StubClient(Exception('boom')))
     result = asyncio.run(server.describe_vpn_gateways())
+    assert isinstance(result, CallToolResult) and result.isError
+
+
+def test_describe_vpn_gateway_route_success(monkeypatch):
+    monkeypatch.setattr(server, '_get_vpn_client', lambda region=None: StubClient())
+    result = asyncio.run(server.describe_vpn_gateway_route('id'))
+    assert result.Message == 'ok'
+
+
+def test_describe_vpn_gateway_route_error(monkeypatch):
+    monkeypatch.setattr(server, '_get_vpn_client', lambda region=None: StubClient(Exception('boom')))
+    result = asyncio.run(server.describe_vpn_gateway_route('id'))
     assert isinstance(result, CallToolResult) and result.isError


### PR DESCRIPTION
## Summary
- add describe_vpn_gateway_route tool to VPN MCP server
- update VPN client and response models for route API
- document the new tool in README
- test the new tool

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'build', ModuleNotFoundError: No module named 'pyzipper', ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686cdd5387fc8333ab72b9ca50833fe5