### PR TITLE
Add VPN gateway routes tool

### DIFF
--- a/server/mcp_server_vpn/README.md
+++ b/server/mcp_server_vpn/README.md
@@ -30,6 +30,11 @@ Skeleton MCP server for VPN related tools. Functionality will be added in future
 - **详细描述**：查询指定的 VPN 网关路由条目详情。
 - **触发示例**：`"查看 VPN 网关路由 vgr-123 的配置"`
 
+### `describe_vpn_gateway_routes`
+
+- **详细描述**：查询满足条件的 VPN 网关路由条目列表。
+- **触发示例**：`"列出 VPN 网关 vgw-123 的路由"`
+
 ## Installation
 
 ### System requirements

--- a/server/mcp_server_vpn/src/mcp_server_vpn/clients/models.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/clients/models.py
@@ -27,3 +27,7 @@ class DescribeVpnGatewaysResponse(BaseResponseModel):
 
 class DescribeVpnGatewayRouteAttributesResponse(BaseResponseModel):
     pass
+
+
+class DescribeVpnGatewayRoutesResponse(BaseResponseModel):
+    pass

--- a/server/mcp_server_vpn/src/mcp_server_vpn/clients/vpn.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/clients/vpn.py
@@ -10,6 +10,7 @@ from volcenginesdkvpn.models import (
     DescribeVpnGatewayAttributesRequest,
     DescribeVpnGatewaysRequest,
     DescribeVpnGatewayRouteAttributesRequest,
+    DescribeVpnGatewayRoutesRequest,
 )
 
 from .models import (
@@ -18,6 +19,7 @@ from .models import (
     DescribeVpnConnectionsResponse,
     DescribeVpnGatewaysResponse,
     DescribeVpnGatewayRouteAttributesResponse,
+    DescribeVpnGatewayRoutesResponse,
 )
 
 
@@ -104,3 +106,9 @@ class VPNClient:
             self.client.describe_vpn_gateway_route_attributes, request
         )
         return self._wrap(resp, DescribeVpnGatewayRouteAttributesResponse)
+
+    def describe_vpn_gateway_routes(
+        self, request: DescribeVpnGatewayRoutesRequest
+    ) -> DescribeVpnGatewayRoutesResponse:
+        resp = self._call(self.client.describe_vpn_gateway_routes, request)
+        return self._wrap(resp, DescribeVpnGatewayRoutesResponse)

--- a/server/mcp_server_vpn/tests/test_server.py
+++ b/server/mcp_server_vpn/tests/test_server.py
@@ -53,6 +53,8 @@ models_mod.DescribeVpnGatewaysRequest = BaseReq
 models_mod.DescribeVpnGatewaysResponse = Resp
 models_mod.DescribeVpnGatewayRouteAttributesRequest = BaseReq
 models_mod.DescribeVpnGatewayRouteAttributesResponse = Resp
+models_mod.DescribeVpnGatewayRoutesRequest = BaseReq
+models_mod.DescribeVpnGatewayRoutesResponse = Resp
 sys.modules['volcenginesdkcore'] = core
 sys.modules['volcenginesdkcore.rest'] = core.rest
 sys.modules['volcenginesdkvpn'] = vpn_mod
@@ -150,6 +152,12 @@ class StubClient:
         )
         return DescribeVpnGatewayRouteAttributesResponse(Message="ok")
 
+    def describe_vpn_gateway_routes(self, req):
+        if self.exc:
+            raise self.exc
+        from mcp_server_vpn.clients.models import DescribeVpnGatewayRoutesResponse
+        return DescribeVpnGatewayRoutesResponse(Message="ok")
+
 
 def test_describe_vpn_connection_success(monkeypatch):
     monkeypatch.setattr(server, '_get_vpn_client', lambda region=None: StubClient())
@@ -206,4 +214,16 @@ def test_describe_vpn_gateway_route_success(monkeypatch):
 def test_describe_vpn_gateway_route_error(monkeypatch):
     monkeypatch.setattr(server, '_get_vpn_client', lambda region=None: StubClient(Exception('boom')))
     result = asyncio.run(server.describe_vpn_gateway_route('id'))
+    assert isinstance(result, CallToolResult) and result.isError
+
+
+def test_describe_vpn_gateway_routes_success(monkeypatch):
+    monkeypatch.setattr(server, '_get_vpn_client', lambda region=None: StubClient())
+    result = asyncio.run(server.describe_vpn_gateway_routes())
+    assert result.Message == 'ok'
+
+
+def test_describe_vpn_gateway_routes_error(monkeypatch):
+    monkeypatch.setattr(server, '_get_vpn_client', lambda region=None: StubClient(Exception('boom')))
+    result = asyncio.run(server.describe_vpn_gateway_routes())
     assert isinstance(result, CallToolResult) and result.isError


### PR DESCRIPTION
## Summary
- add `describe_vpn_gateway_routes` in vpn server
- implement client and models for gateway routes
- document new tool in README
- test listing VPN gateway routes

## Testing
- `pytest server/mcp_server_vpn/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_686cedb583f483338ee54d8e636471d6