### PR TITLE
Add SSL VPN client cert attributes tool

### DIFF
--- a/server/mcp_server_vpn/README.md
+++ b/server/mcp_server_vpn/README.md
@@ -40,6 +40,11 @@ Skeleton MCP server for VPN related tools. Functionality will be added in future
 - **详细描述**：查询满足条件的用户网关列表。
 - **触发示例**：`"列出所有用户网关"`
 
+### `describe_ssl_vpn_client_cert_attributes`
+
+- **详细描述**：查询指定的 SSL 客户端证书详情。
+- **触发示例**：`"查看 SSL 客户端证书 vsc-123 的信息"`
+
 ## Installation
 
 ### System requirements

--- a/server/mcp_server_vpn/src/mcp_server_vpn/clients/models.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/clients/models.py
@@ -35,3 +35,7 @@ class DescribeVpnGatewayRoutesResponse(BaseResponseModel):
 
 class DescribeCustomerGatewaysResponse(BaseResponseModel):
     pass
+
+
+class DescribeSslVpnClientCertAttributesResponse(BaseResponseModel):
+    pass

--- a/server/mcp_server_vpn/src/mcp_server_vpn/clients/vpn.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/clients/vpn.py
@@ -12,6 +12,7 @@ from volcenginesdkvpn.models import (
     DescribeVpnGatewayRouteAttributesRequest,
     DescribeVpnGatewayRoutesRequest,
     DescribeCustomerGatewaysRequest,
+    DescribeSslVpnClientCertAttributesRequest,
 )
 
 from .models import (
@@ -22,6 +23,7 @@ from .models import (
     DescribeVpnGatewayRouteAttributesResponse,
     DescribeVpnGatewayRoutesResponse,
     DescribeCustomerGatewaysResponse,
+    DescribeSslVpnClientCertAttributesResponse,
 )
 
 
@@ -120,3 +122,11 @@ class VPNClient:
     ) -> DescribeCustomerGatewaysResponse:
         resp = self._call(self.client.describe_customer_gateways, request)
         return self._wrap(resp, DescribeCustomerGatewaysResponse)
+
+    def describe_ssl_vpn_client_cert_attributes(
+        self, request: DescribeSslVpnClientCertAttributesRequest
+    ) -> DescribeSslVpnClientCertAttributesResponse:
+        resp = self._call(
+            self.client.describe_ssl_vpn_client_cert_attributes, request
+        )
+        return self._wrap(resp, DescribeSslVpnClientCertAttributesResponse)

--- a/server/mcp_server_vpn/src/mcp_server_vpn/server.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/server.py
@@ -15,6 +15,7 @@ from volcenginesdkvpn.models import (
     DescribeVpnGatewayRouteAttributesRequest,
     DescribeVpnGatewayRoutesRequest,
     DescribeCustomerGatewaysRequest,
+    DescribeSslVpnClientCertAttributesRequest,
 )
 
 from mcp.types import CallToolResult, TextContent, ToolAnnotations
@@ -28,6 +29,7 @@ from .clients.models import (
     DescribeVpnGatewayRouteAttributesResponse,
     DescribeVpnGatewayRoutesResponse,
     DescribeCustomerGatewaysResponse,
+    DescribeSslVpnClientCertAttributesResponse,
 )
 
 logging.basicConfig(
@@ -392,6 +394,42 @@ async def describe_customer_gateways(
         )
     except Exception as exc:
         logger.exception("Error calling describe_customer_gateways")
+        return CallToolResult(
+            isError=True,
+            content=[TextContent(type="text", text=f"查询失败：{exc}")],
+        )
+
+
+@mcp.tool(
+    name="describe_ssl_vpn_client_cert_attributes",
+    description=(
+        '查询指定的SSL客户端证书详情。\\n\\n示例：{"ssl_vpn_client_cert_id":"vsc-xxx","region":"cn-beijing"}'
+    ),
+    annotations=ToolAnnotations(
+        title="Query SSL VPN Client Cert / 查询 SSL VPN 客户端证书详情",
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=True,
+    ),
+)
+async def describe_ssl_vpn_client_cert_attributes(
+    ssl_vpn_client_cert_id: str,
+    region: str | None = None,
+) -> DescribeSslVpnClientCertAttributesResponse | CallToolResult:
+    req = DescribeSslVpnClientCertAttributesRequest(
+        ssl_vpn_client_cert_id=ssl_vpn_client_cert_id
+    )
+    try:
+        vpn_client = _get_vpn_client(region=region)
+        resp = vpn_client.describe_ssl_vpn_client_cert_attributes(req)
+        return resp
+    except ValueError as exc:
+        return CallToolResult(
+            isError=True,
+            content=[TextContent(type="text", text=f"凭证缺失：{exc}")],
+        )
+    except Exception as exc:
+        logger.exception("Error calling describe_ssl_vpn_client_cert_attributes")
         return CallToolResult(
             isError=True,
             content=[TextContent(type="text", text=f"查询失败：{exc}")],

--- a/server/mcp_server_vpn/tests/test_server.py
+++ b/server/mcp_server_vpn/tests/test_server.py
@@ -57,6 +57,8 @@ models_mod.DescribeVpnGatewayRoutesRequest = BaseReq
 models_mod.DescribeVpnGatewayRoutesResponse = Resp
 models_mod.DescribeCustomerGatewaysRequest = BaseReq
 models_mod.DescribeCustomerGatewaysResponse = Resp
+models_mod.DescribeSslVpnClientCertAttributesRequest = BaseReq
+models_mod.DescribeSslVpnClientCertAttributesResponse = Resp
 sys.modules['volcenginesdkcore'] = core
 sys.modules['volcenginesdkcore.rest'] = core.rest
 sys.modules['volcenginesdkvpn'] = vpn_mod
@@ -166,6 +168,14 @@ class StubClient:
         from mcp_server_vpn.clients.models import DescribeCustomerGatewaysResponse
         return DescribeCustomerGatewaysResponse(Message="ok")
 
+    def describe_ssl_vpn_client_cert_attributes(self, req):
+        if self.exc:
+            raise self.exc
+        from mcp_server_vpn.clients.models import (
+            DescribeSslVpnClientCertAttributesResponse,
+        )
+        return DescribeSslVpnClientCertAttributesResponse(Message="ok")
+
 
 def test_describe_vpn_connection_success(monkeypatch):
     monkeypatch.setattr(server, '_get_vpn_client', lambda region=None: StubClient())
@@ -246,4 +256,16 @@ def test_describe_customer_gateways_success(monkeypatch):
 def test_describe_customer_gateways_error(monkeypatch):
     monkeypatch.setattr(server, '_get_vpn_client', lambda region=None: StubClient(Exception('boom')))
     result = asyncio.run(server.describe_customer_gateways())
+    assert isinstance(result, CallToolResult) and result.isError
+
+
+def test_describe_ssl_vpn_client_cert_attributes_success(monkeypatch):
+    monkeypatch.setattr(server, '_get_vpn_client', lambda region=None: StubClient())
+    result = asyncio.run(server.describe_ssl_vpn_client_cert_attributes('id'))
+    assert result.Message == 'ok'
+
+
+def test_describe_ssl_vpn_client_cert_attributes_error(monkeypatch):
+    monkeypatch.setattr(server, '_get_vpn_client', lambda region=None: StubClient(Exception('boom')))
+    result = asyncio.run(server.describe_ssl_vpn_client_cert_attributes('id'))
     assert isinstance(result, CallToolResult) and result.isError


### PR DESCRIPTION
## Summary
- add `describe_ssl_vpn_client_cert_attributes` tool to VPN server
- add client and model support for the new API
- document the new tool in the README
- test success and failure paths

## Testing
- `pytest server/mcp_server_vpn/tests/test_server.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686e2bcea5348333b010cc6c3c9edbe1