### PR TITLE
Add SSL VPN client certs tool

### DIFF
--- a/server/mcp_server_vpn/src/mcp_server_vpn/clients/models.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/clients/models.py
@@ -39,3 +39,7 @@ class DescribeCustomerGatewaysResponse(BaseResponseModel):
 
 class DescribeSslVpnClientCertAttributesResponse(BaseResponseModel):
     pass
+
+
+class DescribeSslVpnClientCertsResponse(BaseResponseModel):
+    pass

--- a/server/mcp_server_vpn/src/mcp_server_vpn/clients/vpn.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/clients/vpn.py
@@ -13,6 +13,7 @@ from volcenginesdkvpn.models import (
     DescribeVpnGatewayRoutesRequest,
     DescribeCustomerGatewaysRequest,
     DescribeSslVpnClientCertAttributesRequest,
+    DescribeSslVpnClientCertsRequest,
 )
 
 from .models import (
@@ -24,6 +25,7 @@ from .models import (
     DescribeVpnGatewayRoutesResponse,
     DescribeCustomerGatewaysResponse,
     DescribeSslVpnClientCertAttributesResponse,
+    DescribeSslVpnClientCertsResponse,
 )
 
 
@@ -130,3 +132,9 @@ class VPNClient:
             self.client.describe_ssl_vpn_client_cert_attributes, request
         )
         return self._wrap(resp, DescribeSslVpnClientCertAttributesResponse)
+
+    def describe_ssl_vpn_client_certs(
+        self, request: DescribeSslVpnClientCertsRequest
+    ) -> DescribeSslVpnClientCertsResponse:
+        resp = self._call(self.client.describe_ssl_vpn_client_certs, request)
+        return self._wrap(resp, DescribeSslVpnClientCertsResponse)

--- a/server/mcp_server_vpn/src/mcp_server_vpn/server.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/server.py
@@ -16,6 +16,7 @@ from volcenginesdkvpn.models import (
     DescribeVpnGatewayRoutesRequest,
     DescribeCustomerGatewaysRequest,
     DescribeSslVpnClientCertAttributesRequest,
+    DescribeSslVpnClientCertsRequest,
 )
 
 from mcp.types import CallToolResult, TextContent, ToolAnnotations
@@ -30,6 +31,7 @@ from .clients.models import (
     DescribeVpnGatewayRoutesResponse,
     DescribeCustomerGatewaysResponse,
     DescribeSslVpnClientCertAttributesResponse,
+    DescribeSslVpnClientCertsResponse,
 )
 
 logging.basicConfig(
@@ -430,6 +432,52 @@ async def describe_ssl_vpn_client_cert_attributes(
         )
     except Exception as exc:
         logger.exception("Error calling describe_ssl_vpn_client_cert_attributes")
+        return CallToolResult(
+            isError=True,
+            content=[TextContent(type="text", text=f"查询失败：{exc}")],
+        )
+
+
+@mcp.tool(
+    name="describe_ssl_vpn_client_certs",
+    description=(
+        '查询满足条件的SSL客户端证书列表。\\n\\n示例：{"page_size":10}'
+    ),
+    annotations=ToolAnnotations(
+        title="Query SSL VPN Client Certs / 查询 SSL VPN 客户端证书列表",
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=True,
+    ),
+)
+async def describe_ssl_vpn_client_certs(
+    page_number: int | None = None,
+    page_size: int | None = None,
+    ssl_vpn_client_cert_ids: list[str] | None = None,
+    ssl_vpn_client_cert_name: str | None = None,
+    ssl_vpn_server_id: str | None = None,
+    tag_filters: list[dict] | None = None,
+    region: str | None = None,
+) -> DescribeSslVpnClientCertsResponse | CallToolResult:
+    req = DescribeSslVpnClientCertsRequest(
+        page_number=page_number,
+        page_size=page_size,
+        ssl_vpn_client_cert_ids=ssl_vpn_client_cert_ids,
+        ssl_vpn_client_cert_name=ssl_vpn_client_cert_name,
+        ssl_vpn_server_id=ssl_vpn_server_id,
+        tag_filters=tag_filters,
+    )
+    try:
+        vpn_client = _get_vpn_client(region=region)
+        resp = vpn_client.describe_ssl_vpn_client_certs(req)
+        return resp
+    except ValueError as exc:
+        return CallToolResult(
+            isError=True,
+            content=[TextContent(type="text", text=f"凭证缺失：{exc}")],
+        )
+    except Exception as exc:
+        logger.exception("Error calling describe_ssl_vpn_client_certs")
         return CallToolResult(
             isError=True,
             content=[TextContent(type="text", text=f"查询失败：{exc}")],

--- a/server/mcp_server_vpn/tests/test_server.py
+++ b/server/mcp_server_vpn/tests/test_server.py
@@ -59,6 +59,8 @@ models_mod.DescribeCustomerGatewaysRequest = BaseReq
 models_mod.DescribeCustomerGatewaysResponse = Resp
 models_mod.DescribeSslVpnClientCertAttributesRequest = BaseReq
 models_mod.DescribeSslVpnClientCertAttributesResponse = Resp
+models_mod.DescribeSslVpnClientCertsRequest = BaseReq
+models_mod.DescribeSslVpnClientCertsResponse = Resp
 sys.modules['volcenginesdkcore'] = core
 sys.modules['volcenginesdkcore.rest'] = core.rest
 sys.modules['volcenginesdkvpn'] = vpn_mod
@@ -176,6 +178,14 @@ class StubClient:
         )
         return DescribeSslVpnClientCertAttributesResponse(Message="ok")
 
+    def describe_ssl_vpn_client_certs(self, req):
+        if self.exc:
+            raise self.exc
+        from mcp_server_vpn.clients.models import (
+            DescribeSslVpnClientCertsResponse,
+        )
+        return DescribeSslVpnClientCertsResponse(Message="ok")
+
 
 def test_describe_vpn_connection_success(monkeypatch):
     monkeypatch.setattr(server, '_get_vpn_client', lambda region=None: StubClient())
@@ -268,4 +278,16 @@ def test_describe_ssl_vpn_client_cert_attributes_success(monkeypatch):
 def test_describe_ssl_vpn_client_cert_attributes_error(monkeypatch):
     monkeypatch.setattr(server, '_get_vpn_client', lambda region=None: StubClient(Exception('boom')))
     result = asyncio.run(server.describe_ssl_vpn_client_cert_attributes('id'))
+    assert isinstance(result, CallToolResult) and result.isError
+
+
+def test_describe_ssl_vpn_client_certs_success(monkeypatch):
+    monkeypatch.setattr(server, '_get_vpn_client', lambda region=None: StubClient())
+    result = asyncio.run(server.describe_ssl_vpn_client_certs())
+    assert result.Message == 'ok'
+
+
+def test_describe_ssl_vpn_client_certs_error(monkeypatch):
+    monkeypatch.setattr(server, '_get_vpn_client', lambda region=None: StubClient(Exception('boom')))
+    result = asyncio.run(server.describe_ssl_vpn_client_certs())
     assert isinstance(result, CallToolResult) and result.isError


### PR DESCRIPTION
## Summary
- support describing SSL VPN client certs in the VPN server
- implement client wrapper and response model
- cover new tool with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e30182da083339aaaf28416a2f234