### PR TITLE
Add DescribeSslVpnServers tool

### DIFF
--- a/server/mcp_server_vpn/README.md
+++ b/server/mcp_server_vpn/README.md
@@ -45,6 +45,11 @@ Skeleton MCP server for VPN related tools. Functionality will be added in future
 - **详细描述**：查询指定的 SSL 客户端证书详情。
 - **触发示例**：`"查看 SSL 客户端证书 vsc-123 的信息"`
 
+### `describe_ssl_vpn_servers`
+
+- **详细描述**：查询满足条件的 SSL 服务端列表。
+- **触发示例**：`"列出所有 SSL 服务端"`
+
 ## Installation
 
 ### System requirements

--- a/server/mcp_server_vpn/src/mcp_server_vpn/clients/models.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/clients/models.py
@@ -43,3 +43,7 @@ class DescribeSslVpnClientCertAttributesResponse(BaseResponseModel):
 
 class DescribeSslVpnClientCertsResponse(BaseResponseModel):
     pass
+
+
+class DescribeSslVpnServersResponse(BaseResponseModel):
+    pass

--- a/server/mcp_server_vpn/src/mcp_server_vpn/clients/vpn.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/clients/vpn.py
@@ -14,6 +14,7 @@ from volcenginesdkvpn.models import (
     DescribeCustomerGatewaysRequest,
     DescribeSslVpnClientCertAttributesRequest,
     DescribeSslVpnClientCertsRequest,
+    DescribeSslVpnServersRequest,
 )
 
 from .models import (
@@ -26,6 +27,7 @@ from .models import (
     DescribeCustomerGatewaysResponse,
     DescribeSslVpnClientCertAttributesResponse,
     DescribeSslVpnClientCertsResponse,
+    DescribeSslVpnServersResponse,
 )
 
 
@@ -138,3 +140,9 @@ class VPNClient:
     ) -> DescribeSslVpnClientCertsResponse:
         resp = self._call(self.client.describe_ssl_vpn_client_certs, request)
         return self._wrap(resp, DescribeSslVpnClientCertsResponse)
+
+    def describe_ssl_vpn_servers(
+        self, request: DescribeSslVpnServersRequest
+    ) -> DescribeSslVpnServersResponse:
+        resp = self._call(self.client.describe_ssl_vpn_servers, request)
+        return self._wrap(resp, DescribeSslVpnServersResponse)

--- a/server/mcp_server_vpn/src/mcp_server_vpn/server.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/server.py
@@ -17,6 +17,7 @@ from volcenginesdkvpn.models import (
     DescribeCustomerGatewaysRequest,
     DescribeSslVpnClientCertAttributesRequest,
     DescribeSslVpnClientCertsRequest,
+    DescribeSslVpnServersRequest,
 )
 
 from mcp.types import CallToolResult, TextContent, ToolAnnotations
@@ -32,6 +33,7 @@ from .clients.models import (
     DescribeCustomerGatewaysResponse,
     DescribeSslVpnClientCertAttributesResponse,
     DescribeSslVpnClientCertsResponse,
+    DescribeSslVpnServersResponse,
 )
 
 logging.basicConfig(
@@ -478,6 +480,52 @@ async def describe_ssl_vpn_client_certs(
         )
     except Exception as exc:
         logger.exception("Error calling describe_ssl_vpn_client_certs")
+        return CallToolResult(
+            isError=True,
+            content=[TextContent(type="text", text=f"查询失败：{exc}")],
+        )
+
+
+@mcp.tool(
+    name="describe_ssl_vpn_servers",
+    description='查询满足条件的SSL服务端列表。\\n\\n示例：{"page_size":20}',
+    annotations=ToolAnnotations(
+        title="Query SSL VPN Servers / 查询 SSL VPN 服务端列表",
+        read_only_hint=True,
+        idempotent_hint=True,
+        open_world_hint=True,
+    ),
+)
+async def describe_ssl_vpn_servers(
+    page_number: int | None = None,
+    page_size: int | None = None,
+    project_name: str | None = None,
+    tag_filters: list[dict] | None = None,
+    vpn_gateway_id: str | None = None,
+    ssl_vpn_server_name: str | None = None,
+    ssl_vpn_server_ids: list[str] | None = None,
+    region: str | None = None,
+) -> DescribeSslVpnServersResponse | CallToolResult:
+    req = DescribeSslVpnServersRequest(
+        page_number=page_number,
+        page_size=page_size,
+        project_name=project_name,
+        tag_filters=tag_filters,
+        vpn_gateway_id=vpn_gateway_id,
+        ssl_vpn_server_name=ssl_vpn_server_name,
+        ssl_vpn_server_ids=ssl_vpn_server_ids,
+    )
+    try:
+        vpn_client = _get_vpn_client(region=region)
+        resp = vpn_client.describe_ssl_vpn_servers(req)
+        return resp
+    except ValueError as exc:
+        return CallToolResult(
+            isError=True,
+            content=[TextContent(type="text", text=f"凭证缺失：{exc}")],
+        )
+    except Exception as exc:
+        logger.exception("Error calling describe_ssl_vpn_servers")
         return CallToolResult(
             isError=True,
             content=[TextContent(type="text", text=f"查询失败：{exc}")],

--- a/server/mcp_server_vpn/tests/test_server.py
+++ b/server/mcp_server_vpn/tests/test_server.py
@@ -61,6 +61,8 @@ models_mod.DescribeSslVpnClientCertAttributesRequest = BaseReq
 models_mod.DescribeSslVpnClientCertAttributesResponse = Resp
 models_mod.DescribeSslVpnClientCertsRequest = BaseReq
 models_mod.DescribeSslVpnClientCertsResponse = Resp
+models_mod.DescribeSslVpnServersRequest = BaseReq
+models_mod.DescribeSslVpnServersResponse = Resp
 sys.modules['volcenginesdkcore'] = core
 sys.modules['volcenginesdkcore.rest'] = core.rest
 sys.modules['volcenginesdkvpn'] = vpn_mod
@@ -186,6 +188,14 @@ class StubClient:
         )
         return DescribeSslVpnClientCertsResponse(Message="ok")
 
+    def describe_ssl_vpn_servers(self, req):
+        if self.exc:
+            raise self.exc
+        from mcp_server_vpn.clients.models import (
+            DescribeSslVpnServersResponse,
+        )
+        return DescribeSslVpnServersResponse(Message="ok")
+
 
 def test_describe_vpn_connection_success(monkeypatch):
     monkeypatch.setattr(server, '_get_vpn_client', lambda region=None: StubClient())
@@ -290,4 +300,16 @@ def test_describe_ssl_vpn_client_certs_success(monkeypatch):
 def test_describe_ssl_vpn_client_certs_error(monkeypatch):
     monkeypatch.setattr(server, '_get_vpn_client', lambda region=None: StubClient(Exception('boom')))
     result = asyncio.run(server.describe_ssl_vpn_client_certs())
+    assert isinstance(result, CallToolResult) and result.isError
+
+
+def test_describe_ssl_vpn_servers_success(monkeypatch):
+    monkeypatch.setattr(server, '_get_vpn_client', lambda region=None: StubClient())
+    result = asyncio.run(server.describe_ssl_vpn_servers())
+    assert result.Message == 'ok'
+
+
+def test_describe_ssl_vpn_servers_error(monkeypatch):
+    monkeypatch.setattr(server, '_get_vpn_client', lambda region=None: StubClient(Exception('boom')))
+    result = asyncio.run(server.describe_ssl_vpn_servers())
     assert isinstance(result, CallToolResult) and result.isError


### PR DESCRIPTION
## Summary
- add DescribeSslVpnServers response model and client helper
- implement `describe_ssl_vpn_servers` tool in VPN MCP server
- document the new tool in the VPN server README
- test DescribeSslVpnServers handler

## Testing
- `pytest -q server/mcp_server_vpn/tests/test_server.py`

------
https://chatgpt.com/codex/tasks/task_e_686e3bbbcbc8833385f83e2d310bfc8f