### PR TITLE
Fix pydantic deprecation warning in VPN server models

### DIFF
--- a/server/mcp_server_vpn/src/mcp_server_vpn/clients/models.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/clients/models.py
@@ -1,12 +1,19 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
+from pydantic.version import VERSION
 
 
 class BaseResponseModel(BaseModel):
     """Generic response model allowing extra fields."""
 
-    class Config:
-        extra = "allow"
-        arbitrary_types_allowed = True
+    if VERSION.startswith("2"):
+        model_config = ConfigDict(
+            extra="allow",
+            arbitrary_types_allowed=True,
+        )
+    else:
+        class Config:
+            extra = "allow"
+            arbitrary_types_allowed = True
 
 
 class DescribeVpnConnectionAttributesResponse(BaseResponseModel):


### PR DESCRIPTION
## Summary
- update VPN client models to use `ConfigDict` when running under pydantic v2
- fall back to class-based `Config` for pydantic v1 for compatibility

## Testing
- `pytest server/mcp_server_vpn -q`
- `pytest server/mcp_server_vpn -W default -q`


------
https://chatgpt.com/codex/tasks/task_e_686f7123fe6c83338a78a4dad1cd90c9