### PR TITLE
Fix uv dependency

### DIFF
--- a/server/mcp_server_vpn/pyproject.toml
+++ b/server/mcp_server_vpn/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "mcp>=1.9.0",
-    "volcengine-python-sdk>=3.0.1",
+    "volcengine>=1.0.101",
 ]
 
 [project.scripts]

--- a/server/mcp_server_vpn/requirements.txt
+++ b/server/mcp_server_vpn/requirements.txt
@@ -68,8 +68,8 @@ typing-inspection==0.4.0
     #   pydantic
     #   pydantic-settings
 urllib3==2.4.0
-    # via volcengine-python-sdk
-uvicorn==0.34.2
+    # via volcengine
+uvicorn==0.34.3
     # via mcp
-volcengine-python-sdk==3.0.1
+volcengine==1.0.101
     # via mcp-server-vpn (pyproject.toml)


### PR DESCRIPTION
## Summary
- include `volcengine` dependency for VPN server

## Testing
- `pytest server/mcp_server_vpn/tests/test_server.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686fbed79de08333adb5dc37cb8f19f1