### PR TITLE
Implement attribute map in VPN client

### DIFF
--- a/server/mcp_server_vpn/src/mcp_server_vpn/clients/base.py
+++ b/server/mcp_server_vpn/src/mcp_server_vpn/clients/base.py
@@ -38,7 +38,14 @@ class BaseApi(Service.Service):
 
     @staticmethod
     def to_params(obj: Any) -> dict[str, Any]:
-        """Convert a request model to a parameters dict, dropping None values."""
+        """Convert a request model to a parameters dict, dropping None values.
+
+        ``volcengine-python-sdk`` request models expose ``attribute_map``
+        describing how Python attribute names map to request parameter keys. This
+        helper applies that mapping so that callers can use snake_case attribute
+        names while the API receives the expected camel case keys.
+        """
+
         if hasattr(obj, "to_dict"):
             data = obj.to_dict()
         elif hasattr(obj, "model_dump"):
@@ -47,6 +54,11 @@ class BaseApi(Service.Service):
             data = obj
         else:
             data = getattr(obj, "__dict__", {})
+
+        attr_map = getattr(obj, "attribute_map", None)
+        if isinstance(attr_map, dict):
+            data = {attr_map.get(k, k): v for k, v in data.items()}
+
         return {k: v for k, v in data.items() if v is not None}
 
     def get(self, action, params, doseq=0):

--- a/server/mcp_server_vpn/tests/test_to_params.py
+++ b/server/mcp_server_vpn/tests/test_to_params.py
@@ -1,0 +1,80 @@
+import os
+import sys
+import types
+
+# Stub minimal volcengine modules so BaseApi can be imported without the SDK
+ve_mod = types.ModuleType('volcengine')
+api_info_mod = types.ModuleType('volcengine.ApiInfo')
+credentials_mod = types.ModuleType('volcengine.Credentials')
+service_info_mod = types.ModuleType('volcengine.ServiceInfo')
+base_service_mod = types.ModuleType('volcengine.base.Service')
+
+class DummyService:
+    def __init__(self, *a, **kw):
+        pass
+
+    def get(self, *a, **kw):
+        return '{}'
+
+api_info_mod.ApiInfo = object
+credentials_mod.Credentials = object
+service_info_mod.ServiceInfo = object
+base_service_mod.Service = DummyService
+base_mod = types.ModuleType('volcengine.base')
+base_mod.Service = base_service_mod
+
+ve_mod.Credentials = credentials_mod
+ve_mod.ServiceInfo = service_info_mod
+
+sys.modules['volcengine'] = ve_mod
+sys.modules['volcengine.ApiInfo'] = api_info_mod
+sys.modules['volcengine.Credentials'] = credentials_mod
+sys.modules['volcengine.ServiceInfo'] = service_info_mod
+sys.modules['volcengine.base'] = base_mod
+sys.modules['volcengine.base.Service'] = base_service_mod
+
+# Stub minimal vpn sdk modules used when importing the clients package
+vpn_mod = types.ModuleType('volcenginesdkvpn')
+vpn_api_mod = types.ModuleType('volcenginesdkvpn.api.vpn_api')
+models_mod = types.ModuleType('volcenginesdkvpn.models')
+sys.modules['volcenginesdkvpn'] = vpn_mod
+sys.modules['volcenginesdkvpn.api'] = types.ModuleType('api')
+sys.modules['volcenginesdkvpn.api.vpn_api'] = vpn_api_mod
+sys.modules['volcenginesdkvpn.models'] = models_mod
+
+# Provide dummy request/response classes to satisfy imports in vpn.py
+for name in [
+    'DescribeVpnConnectionAttributesRequest',
+    'DescribeVpnConnectionsRequest',
+    'DescribeVpnGatewayAttributesRequest',
+    'DescribeVpnGatewaysRequest',
+    'DescribeVpnGatewayRouteAttributesRequest',
+    'DescribeVpnGatewayRoutesRequest',
+    'DescribeCustomerGatewaysRequest',
+    'DescribeSslVpnClientCertAttributesRequest',
+    'DescribeSslVpnClientCertsRequest',
+    'DescribeSslVpnServersRequest',
+]:
+    setattr(models_mod, name, object)
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+from mcp_server_vpn.clients.base import BaseApi
+
+class DummyRequest:
+    attribute_map = {"vpn_connection_id": "VpnConnectionId", "region": "Region"}
+
+    def __init__(self, vpn_connection_id: str, region: str | None = None):
+        self.vpn_connection_id = vpn_connection_id
+        self.region = region
+
+    def to_dict(self):
+        return {
+            "vpn_connection_id": self.vpn_connection_id,
+            "region": self.region,
+        }
+
+
+def test_to_params_applies_attribute_map():
+    req = DummyRequest("vpc-123", None)
+    params = BaseApi.to_params(req)
+    assert params == {"VpnConnectionId": "vpc-123"}


### PR DESCRIPTION
## Summary
- translate request dict keys according to `attribute_map` in VPN BaseApi
- add unit test for `to_params` key translation

## Testing
- `pytest -q server/mcp_server_vpn/tests/test_to_params.py`
- `pytest -q server/mcp_server_vpn/tests`

------
https://chatgpt.com/codex/tasks/task_e_687078b5f64883338b0c5ba126191fe7